### PR TITLE
Updates elm/http dependency to 2.x.x

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,7 +15,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/http": "1.0.0 <= v < 2.0.0",
+        "elm/http": "2.0.0 <= v < 3.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {}


### PR DESCRIPTION
elm/http is now on 2.0.0, https://package.elm-lang.org/packages/elm/http/2.0.0/.
I believe merging this commit will allow us to install the package. Currently when
running `elm install justgook/elm-webdriver` we get 
```
-- CORRUPT JSON --
The elm.json for elm-community/list-extra 2.0.0 got corrupted somehow.
```

etc.